### PR TITLE
Op cholesky add fp64 support

### DIFF
--- a/cinn/hlir/op/contrib/cholesky.cc
+++ b/cinn/hlir/op/contrib/cholesky.cc
@@ -86,7 +86,7 @@ std::vector<framework::shape_t> InferShapeForCholesky(const std::vector<framewor
 
 std::vector<Type> InferDtypeForCholesky(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
   CHECK_EQ(inputs_type.size(), 1U) << "The input's shape size should be 1! Please check again.";
-  CHECK(inputs_type[0].is_float()) << "The input's dtype should be float32! Please check again.";
+  CHECK(inputs_type[0].is_float(32) || inputs_type[0].is_float(64)) << "The input's dtype should be float32 or float64! Please check again.";
   return inputs_type;
 }
 
@@ -102,7 +102,7 @@ CINN_REGISTER_HELPER(cholesky_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForCholesky)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForCholesky))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForCholesky))
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElementWise)
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
       .set_support_level(4);
 
   return true;

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -1183,54 +1183,89 @@ void cinn_call_cholesky_nvgpu(void *v_args, int num_args, int batch_size, int m,
   // See also: https://docs.nvidia.com/cuda/cusolver/index.html#matrix-dense-format
   cublasFillMode_t uplo = upper ? CUBLAS_FILL_MODE_LOWER : CUBLAS_FILL_MODE_UPPER;
   size_t numel          = x->num_elements();
+  uint8_t bits = x->type.bits;
+  uint8_t bytes = bits / 8;
+  CHECK(bits == 32 || bits == 64) << "Unsupported bits = " << bits << " float data type for cholesky";
 
   auto cuda_stream = static_cast<cudaStream_t>(stream);
 
   // Copy data from x to out
   void *x_ptr   = reinterpret_cast<void *>(x->memory);
   void *out_ptr = reinterpret_cast<void *>(out->memory);
-  CUDA_CALL(cudaMemcpyAsync(out_ptr, x_ptr, numel * sizeof(float), cudaMemcpyDeviceToDevice, cuda_stream));
+  CUDA_CALL(cudaMemcpyAsync(out_ptr, x_ptr, numel * bytes, cudaMemcpyDeviceToDevice, cuda_stream));
   // Generate pointer array
-  std::vector<float *> host_out_ptr(batch_size, nullptr);
+  std::vector<void *> host_out_ptr(batch_size, nullptr);
   for (int i = 0; i < batch_size; ++i) {
-    host_out_ptr[i] = reinterpret_cast<float *>(out_ptr) + i * m * m;
+    host_out_ptr[i] = reinterpret_cast<void *>(out_ptr) + i * m * m * bytes;
   }
-  thrust::device_vector<float *> dev_out_ptr(host_out_ptr.begin(), host_out_ptr.end());
+  thrust::device_vector<void *> dev_out_ptr(host_out_ptr.begin(), host_out_ptr.end());
   // Store the return value of each matrix
   std::vector<int> host_info(batch_size, 0);
   thrust::device_vector<int> dev_info(host_info.begin(), host_info.end());
 
   cusolverDnHandle_t handler = CusolverHandle::GetInstance().GetHandle();
   CUSOLVER_CALL(cusolverDnSetStream(handler, cuda_stream));
-  CUSOLVER_CALL(cusolverDnSpotrfBatched(handler,
-                                        uplo,
-                                        m,
-                                        thrust::raw_pointer_cast(dev_out_ptr.data()),
-                                        m,
-                                        thrust::raw_pointer_cast(dev_info.data()),
-                                        batch_size));
+  if (bits == 32) {
+    CUSOLVER_CALL(cusolverDnSpotrfBatched(handler,
+                                          uplo,
+                                          m,
+                                          reinterpret_cast<float **>(dev_out_ptr.data().get()),
+                                          m,
+                                          thrust::raw_pointer_cast(dev_info.data()),
+                                          batch_size));
+  } else if (bits == 64) {
+    CUSOLVER_CALL(cusolverDnDpotrfBatched(handler,
+                                          uplo,
+                                          m,
+                                          reinterpret_cast<double **>(dev_out_ptr.data().get()),
+                                          m,
+                                          thrust::raw_pointer_cast(dev_info.data()),
+                                          batch_size));
+  }
 
   // Set upper/lower triangle of matrices to 0.
-  std::vector<float> matrix(m * m, 0);
-  for (int i = 0; i < batch_size; ++i) {
-    CUDA_CALL(
-        cudaMemcpyAsync(matrix.data(), host_out_ptr[i], m * m * sizeof(float), cudaMemcpyDeviceToHost, cuda_stream));
+  if (bits == 32) {
+    std::vector<float> matrix(batch_size * m * m, 0);
+    CUDA_CALL(cudaMemcpyAsync(matrix.data(), out_ptr, batch_size * m * m * bytes, cudaMemcpyDeviceToHost, cuda_stream));
     CUDA_CALL(cudaStreamSynchronize(cuda_stream));
-    if (upper) {
-      for (int j = 0; j < m; j++) {
-        for (int k = 0; k < j; k++) {
-          matrix[j * m + k] = 0;
+    for (int i = 0; i < batch_size; ++i) {
+      int stride = i * m * m;
+      if (upper) {
+        for (int j = 0; j < m; j++) {
+          for (int k = 0; k < j; k++) {
+            matrix[stride + j * m + k] = 0.0f;
+          }
         }
-      }
-    } else {
-      for (int j = 0; j < m; j++) {
-        for (int k = j + 1; k < m; k++) {
-          matrix[j * m + k] = 0;
+      } else {
+        for (int j = 0; j < m; j++) {
+          for (int k = j + 1; k < m; k++) {
+            matrix[stride + j * m + k] = 0.0f;
+          }
         }
       }
     }
-    CUDA_CALL(
-        cudaMemcpyAsync(host_out_ptr[i], matrix.data(), m * m * sizeof(float), cudaMemcpyHostToDevice, cuda_stream));
+    CUDA_CALL(cudaMemcpyAsync(out_ptr, matrix.data(), batch_size * m * m * bytes, cudaMemcpyHostToDevice, cuda_stream));
+  } else if (bits == 64) {
+    std::vector<double> matrix(batch_size * m * m, 0);
+    CUDA_CALL(cudaMemcpyAsync(matrix.data(), out_ptr, batch_size * m * m * bytes, cudaMemcpyDeviceToHost, cuda_stream));
+    CUDA_CALL(cudaStreamSynchronize(cuda_stream));
+    for (int i = 0; i < batch_size; ++i) {
+      int stride = i * m * m;
+      if (upper) {
+        for (int j = 0; j < m; j++) {
+          for (int k = 0; k < j; k++) {
+            matrix[stride + j * m + k] = 0.0f;
+          }
+        }
+      } else {
+        for (int j = 0; j < m; j++) {
+          for (int k = j + 1; k < m; k++) {
+            matrix[stride + j * m + k] = 0.0f;
+          }
+        }
+      }
+    }
+    CUDA_CALL(cudaMemcpyAsync(out_ptr, matrix.data(), batch_size * m * m * bytes, cudaMemcpyHostToDevice, cuda_stream));
   }
 }
 

--- a/python/tests/ops/test_cholesky_op.py
+++ b/python/tests/ops/test_cholesky_op.py
@@ -36,15 +36,11 @@ class TestCholeskyOp(OpTest):
                       [0.88160539, 1.39001071, 0.48823422],
                       [0.40593964, 0.48823422, 0.19755946]]).astype(np.float32)
         }
-        self.outputs = {
-            "y":
-            np.array([[0.98147416, 0., 0.], [0.89824611, 0.76365221, 0.],
-                      [0.41360193, 0.15284170, 0.05596709]]).astype(np.float32)
-        }
         self.upper = False
 
     def build_paddle_program(self, target):
-        y = paddle.to_tensor(self.outputs["y"], stop_gradient=False)
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
+        y = paddle.linalg.cholesky(x, upper=self.upper)
         self.paddle_outputs = [y]
 
     def build_cinn_program(self, target):
@@ -74,14 +70,6 @@ class TestCholeskyCase1(TestCholeskyOp):
                        [0.40593964, 0.48823422,
                         0.19755946]]]).astype(np.float32)
         }
-        self.outputs = {
-            "y":
-            np.array([[[0.98147416, 0., 0.], [0.89824611, 0.76365221, 0.],
-                       [0.41360193, 0.15284170, 0.05596709]],
-                      [[0.98147416, 0., 0.], [0.89824611, 0.76365221, 0.],
-                       [0.41360193, 0.15284170,
-                        0.05596709]]]).astype(np.float32)
-        }
         self.upper = False
 
 
@@ -95,15 +83,7 @@ class TestCholeskyCase2(TestCholeskyOp):
                       [[0.96329159, 0.88160539, 0.40593964],
                        [0.88160539, 1.39001071, 0.48823422],
                        [0.40593964, 0.48823422,
-                        0.19755946]]]).astype(np.float32)
-        }
-        self.outputs = {
-            "y":
-            np.array([[[0.98147416, 0.89824611, 0.41360193],
-                       [0., 0.76365221, 0.15284170], [0., 0., 0.05596709]],
-                      [[0.98147416, 0.89824611, 0.41360193],
-                       [0., 0.76365221, 0.15284170],
-                       [0., 0., 0.05596709]]]).astype(np.float32)
+                        0.19755946]]]).astype(np.float64)
         }
         self.upper = True
 


### PR DESCRIPTION
1. 增加对fp64数据类型的支持
2. OP pattern kind改为`kNonFusible`
3. 优化了`cudaMemcpy`的传输次数
4. 测试结果与paddle的`paddle.linalg.cholesky`对齐